### PR TITLE
Enumerate all stacks

### DIFF
--- a/gh_stack.py
+++ b/gh_stack.py
@@ -79,16 +79,21 @@ def printAllStacksForAuthor(Author):
 
     Stacks = dict()
     while TS.is_active():
-        NewStacks = dict()
+        # Set of base PRs on which atleast one PR depends.
+        # Final stack list will only contain the top PRs.
+        UsedBases = set()
         for Head in TS.get_ready():
             TS.done(Head)
             Base = Pulls[Head]['baseRefName']
             if Base in Stacks:
-                NewStacks[Head] = Stacks[Base] + [Head]
+                Stacks[Head] = Stacks[Base] + [Head]
+                UsedBases.add(Base)
             else:
-                NewStacks[Head] = [Head]
+                Stacks[Head] = [Head]
+        for Base in UsedBases:
+            if Base in Stacks:
+                Stacks.pop(Base)
 
-        Stacks = NewStacks
     printReversedStackList(Stacks, Pulls)
 
 def main():


### PR DESCRIPTION
In case of multiple stacks in the repo, this only printed the longest stacks (there could be multiple longest stacks in which case all of those would print)

This fixes that to print all available PRs. Singular PRs are also considered to be stacks by themselves.

Could consider adding an option to ignore such singleton stacks.

**This PR stack**
- (changes for this)
- Add tests: #1 
- main